### PR TITLE
chore(package): prepare for dual publishing to npmjs and GitHub Packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish to npm
+name: Publish to npm and GitHub Packages
 
 on:
   release:
@@ -19,7 +19,7 @@ jobs:
           version: 10.13.1
           run_install: false
 
-      - name: Setup Node.js
+      - name: Setup Node.js (npmjs.org)
         uses: actions/setup-node@v4
         with:
           node-version: 18
@@ -32,8 +32,19 @@ jobs:
       - name: Build package
         run: pnpm build
 
-      - name: Publish to npm
+      - name: Publish to npmjs.org
         run: pnpm publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Set up Node.js for GitHub Packages
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          registry-url: 'https://npm.pkg.github.com/'
+          scope: '@interactive-video-labs'
+
+      - name: Publish to GitHub Packages
+        run: pnpm publish --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@interactive-video-labs:registry=https://npm.pkg.github.com/
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/package.json
+++ b/package.json
@@ -45,6 +45,10 @@
     "url": "https://github.com/interactive-video-labs/interactive-video-vue-wrapper/issues"
   },
   "packageManager": "pnpm@10.13.1",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "peerDependencies": {
     "@interactive-video-labs/core": "^0.1.2",
     "vue": "^3.0.0"


### PR DESCRIPTION
- Added `publishConfig` with `access: public` and default registry set to npmjs
- Cleaned up repository URL format
- Ensured compatibility with GitHub Actions-based publish workflows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated publishing workflow to support publishing packages to both npmjs.org and GitHub Packages.
  * Added configuration to enable scoped package publishing and installation from GitHub Packages.
  * Updated package settings to clarify public access and registry details for publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->