### PR TITLE
feat: Add tag-after-merge workflow

### DIFF
--- a/.github/workflows/tag-after-merge.yml
+++ b/.github/workflows/tag-after-merge.yml
@@ -1,0 +1,60 @@
+name: Tag After Merge
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get new version from package.json
+        run: |
+          VERSION=$(jq -r .version package.json)
+          echo "version=$VERSION" >> $GITHUB_ENV
+
+      - name: Get last tag (if exists)
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          # strip leading "v" if present
+          LAST_TAG_STRIPPED=${LAST_TAG#v}
+          echo "last_tag=$LAST_TAG_STRIPPED" >> $GITHUB_ENV
+
+      - name: Check release type (skip patch)
+        run: |
+          NEW=${{ env.version }}
+          OLD=${{ env.last_tag }}
+
+          NEW_MAJOR=$(echo $NEW | cut -d. -f1)
+          NEW_MINOR=$(echo $NEW | cut -d. -f2)
+          NEW_PATCH=$(echo $NEW | cut -d. -f3)
+
+          OLD_MAJOR=$(echo $OLD | cut -d. -f1)
+          OLD_MINOR=$(echo $OLD | cut -d. -f2)
+          OLD_PATCH=$(echo $OLD | cut -d. -f3)
+
+          if [ "$NEW_MAJOR" -gt "$OLD_MAJOR" ]; then
+            echo "release_type=major" >> $GITHUB_ENV
+          elif [ "$NEW_MINOR" -gt "$OLD_MINOR" ]; then
+            echo "release_type=minor" >> $GITHUB_ENV
+          else
+            echo "release_type=patch" >> $GITHUB_ENV
+          fi
+
+      - name: Skip if patch
+        if: env.release_type == 'patch'
+        run: echo "Patch release detected → no tag will be created."
+
+      - name: Create and push git tag
+        if: env.release_type != 'patch'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag v${{ env.version }}
+          git push origin v${{ env.version }}


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow that automatically creates a tag after a merge to the main branch.